### PR TITLE
compatible with wt 2.2 (but no longer compatible with old versions)

### DIFF
--- a/resources/views/layouts/default.phtml
+++ b/resources/views/layouts/default.phtml
@@ -19,6 +19,7 @@ use Fisharebest\Webtrees\Webtrees;
 use Psr\Http\Message\ServerRequestInterface;
 
 use Fisharebest\Webtrees\Http\RequestHandlers\TreePage; // Used for getting tree URL
+use Fisharebest\Webtrees\Registry;
 
 /**
  * @var string                 $content
@@ -57,18 +58,18 @@ use Fisharebest\Webtrees\Http\RequestHandlers\TreePage; // Used for getting tree
         <link rel="manifest" href="<?= e(route(WebmanifestJson::class)) ?>" crossorigin="use-credentials">
 
         <!-- Bootstrap imported into Argon spreadsheet, so no need to load it separately <link rel="stylesheet" href="<?= e(asset('css/vendor.min.css')) ?>"> -->
-        <?php foreach (app(ModuleThemeInterface::class)->stylesheets() as $stylesheet) : ?>
+        <?php foreach (Registry::container()->get(ModuleThemeInterface::class)->stylesheets() as $stylesheet) : ?>
             <link rel="stylesheet" href="<?= e($stylesheet) ?>">
         <?php endforeach ?>
 
         <?= View::stack('styles') ?>
 
-        <?= app(ModuleService::class)->findByInterface(ModuleGlobalInterface::class)->map(static function (ModuleGlobalInterface $module): string {
+        <?= Registry::container()->get(ModuleService::class)->findByInterface(ModuleGlobalInterface::class)->map(static function (ModuleGlobalInterface $module): string {
             return $module->headContent();
         })->implode('') ?>
     </head>
 
-    <body class="wt-global wt-theme-<?= e(app(ModuleThemeInterface::class)->name()) ?> wt-route-<?= e(basename(strtr(Validator::attributes($request)->route()->name ?? '/', ['\\' => '/']))) ?>">
+    <body class="wt-global wt-theme-<?= e(Registry::container()->get(ModuleThemeInterface::class)->name()) ?> wt-route-<?= e(basename(strtr(Validator::attributes($request)->route()->name ?? '/', ['\\' => '/']))) ?>">
         <header class="wt-header-wrapper d-print-none">
             <div id="secondary-header">
                 <div class="container-lg wt-header-container">
@@ -82,7 +83,7 @@ use Fisharebest\Webtrees\Http\RequestHandlers\TreePage; // Used for getting tree
 
                         <nav class="col col-md-auto wt-secondary-navigation">
                             <ul class="nav wt-user-menu">
-                                <?php foreach (app(ModuleThemeInterface::class)->userMenu($tree) as $menu) : ?>
+                                <?php foreach (Registry::container()->get(ModuleThemeInterface::class)->userMenu($tree) as $menu) : ?>
                                     <?= view('components/menu-item', ['menu' => $menu]) ?>
                                 <?php endforeach ?>
                             </ul>
@@ -124,7 +125,7 @@ use Fisharebest\Webtrees\Http\RequestHandlers\TreePage; // Used for getting tree
                         <?php if ($tree !== null) : ?>
                             <nav class="col wt-primary-navigation">
                                 <ul class="nav wt-genealogy-menu">
-                                    <?php foreach (app(ModuleThemeInterface::class)->genealogyMenu($tree) as $menu) : ?>
+                                    <?php foreach (Registry::container()->get(ModuleThemeInterface::class)->genealogyMenu($tree) as $menu) : ?>
                                         <?= view('components/menu-item', ['menu' => $menu]) ?>
                                     <?php endforeach ?>
                                 </ul>
@@ -153,7 +154,7 @@ use Fisharebest\Webtrees\Http\RequestHandlers\TreePage; // Used for getting tree
 
         <footer id="site-footer" class="wt-footers d-print-none">
             <div class="container-lg">
-                <?= app(ModuleService::class)->findByInterface(ModuleFooterInterface::class)->map(static function (ModuleFooterInterface $module) use ($request): string {
+                <?= Registry::container()->get(ModuleService::class)->findByInterface(ModuleFooterInterface::class)->map(static function (ModuleFooterInterface $module) use ($request): string {
                     return $module->getFooter($request);
                 })->implode('') ?>
             </div><!-- /.container-lg -->
@@ -199,7 +200,7 @@ use Fisharebest\Webtrees\Http\RequestHandlers\TreePage; // Used for getting tree
 
         <?= View::stack('javascript') ?>
 
-        <?= app(ModuleService::class)->findByInterface(ModuleGlobalInterface::class)->map(static function (ModuleGlobalInterface $module): string {
+        <?= Registry::container()->get(ModuleService::class)->findByInterface(ModuleGlobalInterface::class)->map(static function (ModuleGlobalInterface $module): string {
             return $module->bodyContent();
         })->implode('') ?>
     </body>


### PR DESCRIPTION
This is a trivial fix to use `Registry::container()` instead of `app()`. It will break compatibility with WT version < 2.2.x 